### PR TITLE
feat: WAF engine health check, request filtering, Prometheus metrics, and bot detection

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -65,7 +65,6 @@ jobs:
             --with github.com/caddy-dns/duckdns \
             --with github.com/caddyserver/replace-response \
             --with "${module_spec}" \
-            --replace github.com/chaitin/t1k-go=github.com/w0n9/t1k-go@latest \
             --output build/caddy-check
 
           ./build/caddy-check list-modules | grep -F "http.handlers.waf_chaitin"
@@ -112,7 +111,6 @@ jobs:
             --with github.com/caddy-dns/duckdns \
             --with github.com/caddyserver/replace-response \
             --with "${CADDY_WAF_MODULE}@${package_version}=${GITHUB_WORKSPACE}" \
-            --replace github.com/chaitin/t1k-go=github.com/w0n9/t1k-go@latest \
             --output build/caddy
 
       - name: Package release archive

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vscode
 Caddyfile
 src/
+docs/

--- a/bot.go
+++ b/bot.go
@@ -1,0 +1,37 @@
+package caddy_waf_t1k
+
+import (
+	"net/http"
+	"strings"
+)
+
+var botCookieNames = []string{
+	"sl_xxx_ug_to",
+	"sl_xxx_ug_to_t",
+	"sl_xxx_ug_fg",
+	"sl_xxx_fig",
+}
+
+// stripBotCookies removes SafeLine internal bot-detection cookies from the request
+// so they are not forwarded to the upstream backend.
+func stripBotCookies(r *http.Request) {
+	cookies := r.Cookies()
+	var kept []string
+	for _, c := range cookies {
+		isBotCookie := false
+		for _, name := range botCookieNames {
+			if c.Name == name {
+				isBotCookie = true
+				break
+			}
+		}
+		if !isBotCookie {
+			kept = append(kept, c.String())
+		}
+	}
+	if len(kept) > 0 {
+		r.Header.Set("Cookie", strings.Join(kept, "; "))
+	} else {
+		r.Header.Del("Cookie")
+	}
+}

--- a/caddyfile.go
+++ b/caddyfile.go
@@ -77,6 +77,33 @@ func (m *CaddyWAF) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				return d.Errf("invalid idle_timeout value: %v", err)
 			}
 			m.IdleTimeout = dur
+		case "health_check_interval":
+			if !d.NextArg() {
+				return d.ArgErr()
+			}
+			dur, err := caddy.ParseDuration(d.Val())
+			if err != nil {
+				return d.Errf("invalid health_check_interval value: %v", err)
+			}
+			m.HealthCheckInterval = caddy.Duration(dur)
+		case "failure_threshold":
+			if !d.NextArg() {
+				return d.ArgErr()
+			}
+			n, err := strconv.Atoi(d.Val())
+			if err != nil {
+				return d.Errf("invalid failure_threshold value: %v", err)
+			}
+			m.FailureThreshold = n
+		case "recovery_threshold":
+			if !d.NextArg() {
+				return d.ArgErr()
+			}
+			n, err := strconv.Atoi(d.Val())
+			if err != nil {
+				return d.Errf("invalid recovery_threshold value: %v", err)
+			}
+			m.RecoveryThreshold = n
 		case "lb_policy":
 			if !d.NextArg() {
 				return d.ArgErr()
@@ -114,6 +141,9 @@ func (m *CaddyWAF) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 //		max_idle 16
 //		max_cap 32
 //		idle_timeout 30s
+//	    health_check_interval 10s
+//	    failure_threshold 3
+//	    recovery_threshold 2
 //	}
 func parseCaddyfileHandler(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error) {
 	var m CaddyWAF

--- a/caddyfile.go
+++ b/caddyfile.go
@@ -159,6 +159,18 @@ func (m *CaddyWAF) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 			default:
 				return d.Errf("log_blocked_requests must be on or off, got %q", d.Val())
 			}
+		case "bot_detect":
+			if !d.NextArg() {
+				return d.ArgErr()
+			}
+			switch d.Val() {
+			case "on":
+				m.BotDetect = true
+			case "off":
+				m.BotDetect = false
+			default:
+				return d.Errf("bot_detect must be on or off, got %q", d.Val())
+			}
 		default:
 			return d.Errf("unrecognized subdirective %s", d.Val())
 		}

--- a/caddyfile.go
+++ b/caddyfile.go
@@ -1,8 +1,10 @@
 package caddy_waf_t1k
 
 import (
+	"fmt"
 	"net"
 	"strconv"
+	"strings"
 
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig"
@@ -125,6 +127,38 @@ func (m *CaddyWAF) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				m.LoadBalancing = new(LoadBalancing)
 			}
 			m.LoadBalancing.SelectionPolicyRaw = caddyconfig.JSONModuleObject(sel, "policy", name, nil)
+		case "skip_content_types":
+			args := d.RemainingArgs()
+			if len(args) == 0 {
+				return d.ArgErr()
+			}
+			m.SkipContentTypes = args
+		case "skip_header":
+			if !d.NextArg() {
+				return d.ArgErr()
+			}
+			m.SkipHeader = d.Val()
+		case "max_body_size":
+			if !d.NextArg() {
+				return d.ArgErr()
+			}
+			n, err := parseByteSize(d.Val())
+			if err != nil {
+				return d.Errf("invalid max_body_size value: %v", err)
+			}
+			m.MaxBodyBytes = n
+		case "log_blocked_requests":
+			if !d.NextArg() {
+				return d.ArgErr()
+			}
+			switch d.Val() {
+			case "on":
+				m.LogBlockedRequests = true
+			case "off":
+				m.LogBlockedRequests = false
+			default:
+				return d.Errf("log_blocked_requests must be on or off, got %q", d.Val())
+			}
 		default:
 			return d.Errf("unrecognized subdirective %s", d.Val())
 		}
@@ -149,4 +183,31 @@ func parseCaddyfileHandler(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler,
 	var m CaddyWAF
 	err := m.UnmarshalCaddyfile(h.Dispenser)
 	return m, err
+}
+
+// parseByteSize parses human-readable byte sizes like "1MB", "512KB", "1073741824".
+func parseByteSize(s string) (int64, error) {
+	if n, err := strconv.ParseInt(s, 10, 64); err == nil {
+		return n, nil
+	}
+	suffixes := []struct {
+		suffix string
+		mult   int64
+	}{
+		{"GB", 1024 * 1024 * 1024},
+		{"MB", 1024 * 1024},
+		{"KB", 1024},
+	}
+	upper := strings.ToUpper(s)
+	for _, sf := range suffixes {
+		if strings.HasSuffix(upper, sf.suffix) {
+			numStr := s[:len(s)-len(sf.suffix)]
+			n, err := strconv.ParseInt(strings.TrimSpace(numStr), 10, 64)
+			if err != nil {
+				return 0, fmt.Errorf("invalid byte size %q: %v", s, err)
+			}
+			return n * sf.mult, nil
+		}
+	}
+	return 0, fmt.Errorf("unrecognized byte size format %q (use KB, MB, GB or plain bytes)", s)
 }

--- a/filter.go
+++ b/filter.go
@@ -1,0 +1,33 @@
+package caddy_waf_t1k
+
+import (
+	"net/http"
+	"strings"
+)
+
+type filterResult int
+
+const (
+	filterPass     filterResult = iota
+	filterSkipAll               // skip entire detection
+	filterSkipBody              // skip body detection only; headers still inspected
+)
+
+// checkFilter returns how a request should be handled before WAF detection.
+func checkFilter(r *http.Request, skipContentTypes []string, skipHeader string, maxBodyBytes int64) filterResult {
+	if skipHeader != "" && r.Header.Get(skipHeader) != "" {
+		return filterSkipAll
+	}
+	ct := r.Header.Get("Content-Type")
+	if ct != "" {
+		for _, skip := range skipContentTypes {
+			if strings.HasPrefix(ct, skip) {
+				return filterSkipAll
+			}
+		}
+	}
+	if maxBodyBytes > 0 && r.ContentLength > maxBodyBytes {
+		return filterSkipBody
+	}
+	return filterPass
+}

--- a/filter_test.go
+++ b/filter_test.go
@@ -1,0 +1,67 @@
+package caddy_waf_t1k
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCheckFilter_SkipHeader(t *testing.T) {
+	r := httptest.NewRequest("POST", "/", nil)
+	r.Header.Set("X-Internal-Token", "secret")
+	got := checkFilter(r, nil, "X-Internal-Token", 0)
+	if got != filterSkipAll {
+		t.Fatalf("expected filterSkipAll, got %d", got)
+	}
+}
+
+func TestCheckFilter_HeaderAbsent_NoSkip(t *testing.T) {
+	r := httptest.NewRequest("POST", "/", nil)
+	got := checkFilter(r, nil, "X-Internal-Token", 0)
+	if got != filterPass {
+		t.Fatalf("expected filterPass when header absent, got %d", got)
+	}
+}
+
+func TestCheckFilter_SkipContentType_Exact(t *testing.T) {
+	r := httptest.NewRequest("POST", "/upload", nil)
+	r.Header.Set("Content-Type", "image/jpeg")
+	got := checkFilter(r, []string{"image/jpeg", "image/png"}, "", 0)
+	if got != filterSkipAll {
+		t.Fatalf("expected filterSkipAll, got %d", got)
+	}
+}
+
+func TestCheckFilter_SkipContentType_PrefixMatch(t *testing.T) {
+	r := httptest.NewRequest("POST", "/", nil)
+	r.Header.Set("Content-Type", "image/jpeg; charset=utf-8")
+	got := checkFilter(r, []string{"image/jpeg"}, "", 0)
+	if got != filterSkipAll {
+		t.Fatalf("expected filterSkipAll for prefix match, got %d", got)
+	}
+}
+
+func TestCheckFilter_SkipBody_OverSize(t *testing.T) {
+	r := httptest.NewRequest("POST", "/", nil)
+	r.ContentLength = 10 * 1024 * 1024 // 10MB
+	got := checkFilter(r, nil, "", 1*1024*1024)
+	if got != filterSkipBody {
+		t.Fatalf("expected filterSkipBody, got %d", got)
+	}
+}
+
+func TestCheckFilter_BodyUnderSize_Pass(t *testing.T) {
+	r := httptest.NewRequest("POST", "/", nil)
+	r.ContentLength = 512 * 1024 // 512KB
+	got := checkFilter(r, nil, "", 1*1024*1024)
+	if got != filterPass {
+		t.Fatalf("expected filterPass for under-size body, got %d", got)
+	}
+}
+
+func TestCheckFilter_NoRules_Pass(t *testing.T) {
+	r := httptest.NewRequest("GET", "/", nil)
+	got := checkFilter(r, nil, "", 0)
+	if got != filterPass {
+		t.Fatalf("expected filterPass with no rules, got %d", got)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/W0n9/caddy_waf_t1k
 
 go 1.25.0
 
-replace github.com/chaitin/t1k-go => ./src/t1k-go
+replace github.com/chaitin/t1k-go => github.com/w0n9/t1k-go v1.5.9
 
 require (
 	github.com/caddyserver/caddy/v2 v2.11.2

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/W0n9/caddy_waf_t1k
 
 go 1.25.0
 
-replace github.com/chaitin/t1k-go => github.com/w0n9/t1k-go v1.5.8
+replace github.com/chaitin/t1k-go => ./src/t1k-go
 
 require (
 	github.com/caddyserver/caddy/v2 v2.11.2

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ replace github.com/chaitin/t1k-go => github.com/w0n9/t1k-go v1.5.8
 require (
 	github.com/caddyserver/caddy/v2 v2.11.2
 	github.com/chaitin/t1k-go v0.0.0-00010101000000-000000000000
+	github.com/prometheus/client_golang v1.23.2
 	go.uber.org/zap v1.27.1
 )
 
@@ -74,7 +75,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -325,8 +325,8 @@ github.com/tailscale/tscert v0.0.0-20251216020129-aea342f6d747/go.mod h1:ejPAJui
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v1.22.17 h1:SYzXoiPfQjHBbkYxbew5prZHS1TOLT3ierW8SYLqtVQ=
 github.com/urfave/cli v1.22.17/go.mod h1:b0ht0aqgH/6pBYzzxURyrM4xXNgsoT/n2ZzwQiEhNVo=
-github.com/w0n9/t1k-go v1.5.8 h1:3JWsyyULOKhDsw8AK97aMqn6n3ysJccx/tceowi0Ofg=
-github.com/w0n9/t1k-go v1.5.8/go.mod h1:se+KorVv1JUbRMk7KjjvF3E75cRrDhWlaQ6wEo2FZHQ=
+github.com/w0n9/t1k-go v1.5.9 h1:fSTMzQKWkPegm4m7T1+nmpO1fnFmVLZEIbuQCpooKa8=
+github.com/w0n9/t1k-go v1.5.9/go.mod h1:se+KorVv1JUbRMk7KjjvF3E75cRrDhWlaQ6wEo2FZHQ=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zeebo/assert v1.1.0 h1:hU1L1vLTHsnO8x8c9KAR5GmM5QscxHg5RNU5z5qbUWY=

--- a/health.go
+++ b/health.go
@@ -55,10 +55,7 @@ func (e *engineEntry) updateHealth(success bool, failureThreshold, recoveryThres
 // startHealthCheck starts a background goroutine that probes the engine via TCP dial.
 // The goroutine exits when ctx is cancelled.
 func (e *engineEntry) startHealthCheck(ctx context.Context, interval time.Duration, failureThreshold, recoveryThreshold int32, logger *zap.Logger) {
-	dialTimeout := interval / 2
-	if dialTimeout < 500*time.Millisecond {
-		dialTimeout = 500 * time.Millisecond
-	}
+	dialTimeout := max(interval/2, 500*time.Millisecond)
 	go func() {
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()

--- a/health.go
+++ b/health.go
@@ -1,0 +1,78 @@
+package caddy_waf_t1k
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"sync/atomic"
+	"time"
+
+	t1k "github.com/chaitin/t1k-go"
+	"github.com/chaitin/t1k-go/detection"
+	"go.uber.org/zap"
+)
+
+// detector abstracts WAF engine detection for testability.
+type detector interface {
+	DetectHttpRequest(*http.Request) (*detection.Result, error)
+}
+
+type engineEntry struct {
+	pool      detector
+	addr      string
+	healthy   atomic.Bool
+	failCount atomic.Int32
+	okCount   atomic.Int32
+}
+
+func newEngineEntry(pool *t1k.ChannelPool, addr string) *engineEntry {
+	e := &engineEntry{pool: pool, addr: addr}
+	e.healthy.Store(true)
+	return e
+}
+
+// updateHealth updates engine health state based on a single probe result.
+// Called by the health check goroutine; also usable directly in tests.
+func (e *engineEntry) updateHealth(success bool, failureThreshold, recoveryThreshold int32, logger *zap.Logger) {
+	if success {
+		e.failCount.Store(0)
+		newOK := e.okCount.Add(1)
+		if !e.healthy.Load() && newOK >= recoveryThreshold {
+			e.healthy.Store(true)
+			logger.Warn("WAF engine recovered",
+				zap.String("engine_addr", e.addr))
+		}
+	} else {
+		e.okCount.Store(0)
+		newFail := e.failCount.Add(1)
+		if e.healthy.Load() && newFail >= failureThreshold {
+			e.healthy.Store(false)
+			logger.Warn("WAF engine marked unhealthy",
+				zap.String("engine_addr", e.addr),
+				zap.Int32("fail_count", newFail))
+		}
+	}
+}
+
+// startHealthCheck starts a background goroutine that probes the engine via TCP dial.
+// The goroutine exits when ctx is cancelled.
+func (e *engineEntry) startHealthCheck(ctx context.Context, interval time.Duration, failureThreshold, recoveryThreshold int32, logger *zap.Logger) {
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				conn, err := net.DialTimeout("tcp", e.addr, 2*time.Second)
+				if err == nil {
+					conn.Close()
+					e.updateHealth(true, failureThreshold, recoveryThreshold, logger)
+				} else {
+					e.updateHealth(false, failureThreshold, recoveryThreshold, logger)
+				}
+			}
+		}
+	}()
+}

--- a/health.go
+++ b/health.go
@@ -18,7 +18,7 @@ type detector interface {
 }
 
 type engineEntry struct {
-	pool      detector
+	engine    detector
 	addr      string
 	healthy   atomic.Bool
 	failCount atomic.Int32
@@ -26,7 +26,7 @@ type engineEntry struct {
 }
 
 func newEngineEntry(pool *t1k.ChannelPool, addr string) *engineEntry {
-	e := &engineEntry{pool: pool, addr: addr}
+	e := &engineEntry{engine: pool, addr: addr}
 	e.healthy.Store(true)
 	return e
 }
@@ -37,16 +37,14 @@ func (e *engineEntry) updateHealth(success bool, failureThreshold, recoveryThres
 	if success {
 		e.failCount.Store(0)
 		newOK := e.okCount.Add(1)
-		if !e.healthy.Load() && newOK >= recoveryThreshold {
-			e.healthy.Store(true)
-			logger.Warn("WAF engine recovered",
+		if newOK >= recoveryThreshold && e.healthy.CompareAndSwap(false, true) {
+			logger.Info("WAF engine recovered",
 				zap.String("engine_addr", e.addr))
 		}
 	} else {
 		e.okCount.Store(0)
 		newFail := e.failCount.Add(1)
-		if e.healthy.Load() && newFail >= failureThreshold {
-			e.healthy.Store(false)
+		if newFail >= failureThreshold && e.healthy.CompareAndSwap(true, false) {
 			logger.Warn("WAF engine marked unhealthy",
 				zap.String("engine_addr", e.addr),
 				zap.Int32("fail_count", newFail))
@@ -57,6 +55,10 @@ func (e *engineEntry) updateHealth(success bool, failureThreshold, recoveryThres
 // startHealthCheck starts a background goroutine that probes the engine via TCP dial.
 // The goroutine exits when ctx is cancelled.
 func (e *engineEntry) startHealthCheck(ctx context.Context, interval time.Duration, failureThreshold, recoveryThreshold int32, logger *zap.Logger) {
+	dialTimeout := interval / 2
+	if dialTimeout < 500*time.Millisecond {
+		dialTimeout = 500 * time.Millisecond
+	}
 	go func() {
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
@@ -65,7 +67,7 @@ func (e *engineEntry) startHealthCheck(ctx context.Context, interval time.Durati
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				conn, err := net.DialTimeout("tcp", e.addr, 2*time.Second)
+				conn, err := net.DialTimeout("tcp", e.addr, dialTimeout)
 				if err == nil {
 					conn.Close()
 					e.updateHealth(true, failureThreshold, recoveryThreshold, logger)

--- a/health.go
+++ b/health.go
@@ -50,6 +50,7 @@ func (e *engineEntry) updateHealth(success bool, failureThreshold, recoveryThres
 				zap.Int32("fail_count", newFail))
 		}
 	}
+	setEngineHealthy(e.addr, e.healthy.Load())
 }
 
 // startHealthCheck starts a background goroutine that probes the engine via TCP dial.

--- a/health_test.go
+++ b/health_test.go
@@ -1,0 +1,71 @@
+package caddy_waf_t1k
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func TestUpdateHealth_MarkUnhealthy(t *testing.T) {
+	logger := zap.NewNop()
+	e := &engineEntry{addr: "127.0.0.1:8000"}
+	e.healthy.Store(true)
+
+	e.updateHealth(false, 3, 2, logger)
+	e.updateHealth(false, 3, 2, logger)
+	if !e.healthy.Load() {
+		t.Fatal("should still be healthy after 2 failures (threshold=3)")
+	}
+
+	e.updateHealth(false, 3, 2, logger)
+	if e.healthy.Load() {
+		t.Fatal("should be unhealthy after 3 consecutive failures")
+	}
+}
+
+func TestUpdateHealth_Recovery(t *testing.T) {
+	logger := zap.NewNop()
+	e := &engineEntry{addr: "127.0.0.1:8000"}
+	e.healthy.Store(false)
+	e.failCount.Store(3)
+
+	e.updateHealth(true, 3, 2, logger)
+	if e.healthy.Load() {
+		t.Fatal("should still be unhealthy after 1 success (threshold=2)")
+	}
+
+	e.updateHealth(true, 3, 2, logger)
+	if !e.healthy.Load() {
+		t.Fatal("should be healthy after 2 consecutive successes")
+	}
+}
+
+func TestUpdateHealth_FailCountResetOnSuccess(t *testing.T) {
+	logger := zap.NewNop()
+	e := &engineEntry{addr: "127.0.0.1:8000"}
+	e.healthy.Store(true)
+
+	e.updateHealth(false, 3, 2, logger)
+	e.updateHealth(false, 3, 2, logger)
+	e.updateHealth(true, 3, 2, logger)
+
+	if e.failCount.Load() != 0 {
+		t.Fatalf("failCount should be 0 after success, got %d", e.failCount.Load())
+	}
+	if !e.healthy.Load() {
+		t.Fatal("should still be healthy")
+	}
+}
+
+func TestUpdateHealth_OkCountResetOnFailure(t *testing.T) {
+	logger := zap.NewNop()
+	e := &engineEntry{addr: "127.0.0.1:8000"}
+	e.healthy.Store(false)
+
+	e.updateHealth(true, 3, 2, logger)
+	e.updateHealth(false, 3, 2, logger)
+
+	if e.okCount.Load() != 0 {
+		t.Fatalf("okCount should be 0 after failure, got %d", e.okCount.Load())
+	}
+}

--- a/health_test.go
+++ b/health_test.go
@@ -27,7 +27,6 @@ func TestUpdateHealth_Recovery(t *testing.T) {
 	logger := zap.NewNop()
 	e := &engineEntry{addr: "127.0.0.1:8000"}
 	e.healthy.Store(false)
-	e.failCount.Store(3)
 
 	e.updateHealth(true, 3, 2, logger)
 	if e.healthy.Load() {

--- a/load_balancer.go
+++ b/load_balancer.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
-	"github.com/chaitin/t1k-go"
 )
 
 func init() {
@@ -18,23 +17,32 @@ func init() {
 
 // LoadBalancing has parameters related to load balancing.
 type LoadBalancing struct {
-	// A selection policy is how to choose an available backend.
-	// The default policy is random selection.
 	SelectionPolicyRaw json.RawMessage `json:"selection_policy,omitempty" caddy:"namespace=http.waf_chaitin.selection_policies inline_key=policy"`
-
-	SelectionPolicy Selector `json:"-"`
+	SelectionPolicy    Selector        `json:"-"`
 }
 
-// Selector selects an available upstream from the pool.
+// Selector selects an available engine from the pool.
 type Selector interface {
-	Select(EnginePool, *http.Request, http.ResponseWriter) *t1k.ChannelPool
+	Select(EnginePool, *http.Request, http.ResponseWriter) *engineEntry
 }
 
-// RandomSelection is a policy that selects
-// an available host at random.
+// healthyPool returns only healthy engines. Returns the full pool if all are unhealthy (fail-open).
+func healthyPool(pool EnginePool) EnginePool {
+	var healthy EnginePool
+	for _, e := range pool {
+		if e.healthy.Load() {
+			healthy = append(healthy, e)
+		}
+	}
+	if len(healthy) == 0 {
+		return pool
+	}
+	return healthy
+}
+
+// RandomSelection selects an available engine at random.
 type RandomSelection struct{}
 
-// CaddyModule returns the Caddy module information.
 func (RandomSelection) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
 		ID:  "http.waf_chaitin.selection_policies.random",
@@ -42,42 +50,35 @@ func (RandomSelection) CaddyModule() caddy.ModuleInfo {
 	}
 }
 
-// Select returns an available host, if any.
-func (r RandomSelection) Select(pool EnginePool, request *http.Request, _ http.ResponseWriter) *t1k.ChannelPool {
-	return selectRandomHost(pool)
+func (r RandomSelection) Select(pool EnginePool, _ *http.Request, _ http.ResponseWriter) *engineEntry {
+	return selectRandomEntry(healthyPool(pool))
 }
 
-// UnmarshalCaddyfile sets up the module from Caddyfile tokens.
 func (r *RandomSelection) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
-	d.Next() // consume policy name
+	d.Next()
 	if d.NextArg() {
 		return d.ArgErr()
 	}
 	return nil
 }
 
-// selectRandomHost returns a random available host
-func selectRandomHost(pool []*t1k.ChannelPool) *t1k.ChannelPool {
-	// use reservoir sampling because the number of available
-	// hosts isn't known: https://en.wikipedia.org/wiki/Reservoir_sampling
-	var randomHost *t1k.ChannelPool
+func selectRandomEntry(pool EnginePool) *engineEntry {
+	var chosen *engineEntry
 	var count int
-	for _, upstream := range pool {
+	for _, e := range pool {
 		count++
 		if (weakrand.Int() % count) == 0 { //nolint:gosec
-			randomHost = upstream
+			chosen = e
 		}
 	}
-	return randomHost
+	return chosen
 }
 
-// RoundRobinSelection is a policy that selects
-// a host based on round-robin ordering.
+// RoundRobinSelection selects an engine based on round-robin ordering.
 type RoundRobinSelection struct {
 	robin uint32
 }
 
-// CaddyModule returns the Caddy module information.
 func (RoundRobinSelection) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
 		ID:  "http.waf_chaitin.selection_policies.round_robin",
@@ -85,20 +86,18 @@ func (RoundRobinSelection) CaddyModule() caddy.ModuleInfo {
 	}
 }
 
-// Select returns an available host, if any.
-func (r *RoundRobinSelection) Select(pool EnginePool, _ *http.Request, _ http.ResponseWriter) *t1k.ChannelPool {
-	n := uint32(len(pool))
+func (r *RoundRobinSelection) Select(pool EnginePool, _ *http.Request, _ http.ResponseWriter) *engineEntry {
+	candidates := healthyPool(pool)
+	n := uint32(len(candidates))
 	if n == 0 {
 		return nil
 	}
 	robin := atomic.AddUint32(&r.robin, 1)
-	host := pool[robin%n]
-	return host
+	return candidates[robin%n]
 }
 
-// UnmarshalCaddyfile sets up the module from Caddyfile tokens.
 func (r *RoundRobinSelection) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
-	d.Next() // consume policy name
+	d.Next()
 	if d.NextArg() {
 		return d.ArgErr()
 	}

--- a/load_balancer_test.go
+++ b/load_balancer_test.go
@@ -1,0 +1,105 @@
+package caddy_waf_t1k
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func makeTestEntry(addr string, healthy bool) *engineEntry {
+	e := &engineEntry{addr: addr}
+	e.healthy.Store(healthy)
+	return e
+}
+
+func TestRandomSelection_SkipsUnhealthyEngines(t *testing.T) {
+	pool := EnginePool{
+		makeTestEntry("1.1.1.1:8000", false),
+		makeTestEntry("2.2.2.2:8000", true),
+		makeTestEntry("3.3.3.3:8000", false),
+	}
+	sel := RandomSelection{}
+	r := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+
+	for i := 0; i < 30; i++ {
+		got := sel.Select(pool, r, w)
+		if got == nil {
+			t.Fatal("Select returned nil")
+		}
+		if got.addr != "2.2.2.2:8000" {
+			t.Fatalf("expected healthy engine 2.2.2.2:8000, got %s", got.addr)
+		}
+	}
+}
+
+func TestRandomSelection_FailOpen_WhenAllUnhealthy(t *testing.T) {
+	pool := EnginePool{
+		makeTestEntry("1.1.1.1:8000", false),
+		makeTestEntry("2.2.2.2:8000", false),
+	}
+	sel := RandomSelection{}
+	r := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+
+	got := sel.Select(pool, r, w)
+	if got == nil {
+		t.Fatal("Select should fail-open and return an engine when all are unhealthy")
+	}
+}
+
+func TestRoundRobinSelection_SkipsUnhealthyEngines(t *testing.T) {
+	pool := EnginePool{
+		makeTestEntry("1.1.1.1:8000", true),
+		makeTestEntry("2.2.2.2:8000", false),
+		makeTestEntry("3.3.3.3:8000", true),
+	}
+	sel := &RoundRobinSelection{}
+	r := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+
+	for i := 0; i < 10; i++ {
+		got := sel.Select(pool, r, w)
+		if got == nil {
+			t.Fatal("Select returned nil")
+		}
+		if got.addr == "2.2.2.2:8000" {
+			t.Fatal("unhealthy engine should not be selected")
+		}
+	}
+}
+
+func TestRoundRobinSelection_FailOpen_WhenAllUnhealthy(t *testing.T) {
+	pool := EnginePool{
+		makeTestEntry("1.1.1.1:8000", false),
+	}
+	sel := &RoundRobinSelection{}
+	r := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+
+	got := sel.Select(pool, r, w)
+	if got == nil {
+		t.Fatal("Select should fail-open and return an engine when all are unhealthy")
+	}
+}
+
+func TestHealthyPool_AllHealthy(t *testing.T) {
+	pool := EnginePool{
+		makeTestEntry("a", true),
+		makeTestEntry("b", true),
+	}
+	got := healthyPool(pool)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 healthy engines, got %d", len(got))
+	}
+}
+
+func TestHealthyPool_FallbackWhenAllUnhealthy(t *testing.T) {
+	pool := EnginePool{
+		makeTestEntry("a", false),
+		makeTestEntry("b", false),
+	}
+	got := healthyPool(pool)
+	if len(got) != 2 {
+		t.Fatalf("expected fallback to full pool (2), got %d", len(got))
+	}
+}

--- a/metrics.go
+++ b/metrics.go
@@ -1,0 +1,75 @@
+package caddy_waf_t1k
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var wafMetrics = struct {
+	once           sync.Once
+	requestsTotal  *prometheus.CounterVec
+	detectDuration *prometheus.HistogramVec
+	engineHealthy  *prometheus.GaugeVec
+}{}
+
+func initWAFMetrics(registry *prometheus.Registry) {
+	const ns, sub = "caddy", "waf_chaitin"
+	wafMetrics.once.Do(func() {
+		wafMetrics.requestsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: ns,
+			Subsystem: sub,
+			Name:      "requests_total",
+			Help:      "Total WAF-inspected requests by result (allowed, blocked, error, skipped).",
+		}, []string{"result"})
+		wafMetrics.detectDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: ns,
+			Subsystem: sub,
+			Name:      "detect_duration_seconds",
+			Help:      "WAF engine detection round-trip latency.",
+			Buckets:   prometheus.DefBuckets,
+		}, []string{})
+		wafMetrics.engineHealthy = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: ns,
+			Subsystem: sub,
+			Name:      "engine_healthy",
+			Help:      "WAF engine health status: 1=healthy, 0=unhealthy.",
+		}, []string{"addr"})
+	})
+	for _, c := range []prometheus.Collector{
+		wafMetrics.requestsTotal,
+		wafMetrics.detectDuration,
+		wafMetrics.engineHealthy,
+	} {
+		if err := registry.Register(c); err != nil {
+			var are prometheus.AlreadyRegisteredError
+			if !errors.As(err, &are) {
+				panic(err)
+			}
+		}
+	}
+}
+
+func recordRequest(result string) {
+	if wafMetrics.requestsTotal != nil {
+		wafMetrics.requestsTotal.WithLabelValues(result).Inc()
+	}
+}
+
+func recordDetectDuration(seconds float64) {
+	if wafMetrics.detectDuration != nil {
+		wafMetrics.detectDuration.WithLabelValues().Observe(seconds)
+	}
+}
+
+func setEngineHealthy(addr string, healthy bool) {
+	if wafMetrics.engineHealthy == nil {
+		return
+	}
+	v := 0.0
+	if healthy {
+		v = 1.0
+	}
+	wafMetrics.engineHealthy.WithLabelValues(addr).Set(v)
+}

--- a/waf.go
+++ b/waf.go
@@ -173,6 +173,14 @@ func (m CaddyWAF) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyht
 		return next.ServeHTTP(w, r)
 	}
 
+	if m.BotDetect && result.BotDetected() {
+		stripBotCookies(r)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(result.BotBody)
+		recordRequest("bot_challenge")
+		return nil
+	}
+
 	if result.Blocked() {
 		if m.LogBlockedRequests {
 			m.logger.Warn("WAF blocked request",

--- a/waf.go
+++ b/waf.go
@@ -1,11 +1,12 @@
 package caddy_waf_t1k
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"time"
 
-	"github.com/chaitin/t1k-go"
+	t1k "github.com/chaitin/t1k-go"
 
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
@@ -18,28 +19,39 @@ func init() {
 	caddy.RegisterModule(CaddyWAF{})
 }
 
-type EnginePool []*t1k.ChannelPool
+// EnginePool is a slice of WAF engine entries.
+type EnginePool []*engineEntry
 
 // CaddyWAF implements an HTTP handler for WAF.
 type CaddyWAF struct {
 	logger *zap.Logger
+	cancel context.CancelFunc
 
-	WafEngineAddrs []string `json:"waf_engine_addrs,omitempty"` // WAF Engine address, expects a URL or IP address
+	WafEngineAddrs []string `json:"waf_engine_addrs,omitempty"`
+	Engines        EnginePool
 
-	// Multiple WAF engine pools
-	Engines EnginePool
-
-	// Load balancing distributes load/requests between backends.
 	LoadBalancing *LoadBalancing `json:"load_balancing,omitempty"`
 
-	InitialCap  int           `json:"initial_cap,omitempty"`  // InitialCap is the initial capacity of the pool
-	MaxIdle     int           `json:"max_idle,omitempty"`     // MaxIdle is the maximum number of idle connections in the pool
-	MaxCap      int           `json:"max_cap,omitempty"`      // MaxCap is the maximum capacity of the pool
-	IdleTimeout time.Duration `json:"idle_timeout,omitempty"` // IdleTimeout is the duration after which an idle connection is closed
-	// block_tpl_path string `json:"block_tpl_path"` // Block template path
+	InitialCap  int           `json:"initial_cap,omitempty"`
+	MaxIdle     int           `json:"max_idle,omitempty"`
+	MaxCap      int           `json:"max_cap,omitempty"`
+	IdleTimeout time.Duration `json:"idle_timeout,omitempty"`
+
+	// Batch 1: health check config
+	HealthCheckInterval caddy.Duration `json:"health_check_interval,omitempty"`
+	FailureThreshold    int            `json:"failure_threshold,omitempty"`
+	RecoveryThreshold   int            `json:"recovery_threshold,omitempty"`
+
+	// Batch 2: filter + observability
+	SkipContentTypes   []string `json:"skip_content_types,omitempty"`
+	SkipHeader         string   `json:"skip_header,omitempty"`
+	MaxBodyBytes       int64    `json:"max_body_bytes,omitempty"`
+	LogBlockedRequests bool     `json:"log_blocked_requests,omitempty"`
+
+	// Batch 3: bot detection
+	BotDetect bool `json:"bot_detect,omitempty"`
 }
 
-// CaddyModule returns the Caddy module information.
 func (CaddyWAF) CaddyModule() caddy.ModuleInfo {
 	return caddy.ModuleInfo{
 		ID:  "http.handlers.waf_chaitin",
@@ -47,16 +59,6 @@ func (CaddyWAF) CaddyModule() caddy.ModuleInfo {
 	}
 }
 
-// initDetect initializes the WAF engine.
-func initDetect(pc *t1k.PoolConfig) (*t1k.ChannelPool, error) {
-	server, err := t1k.NewChannelPool(pc)
-	if err != nil {
-		return nil, err
-	}
-	return server, nil
-}
-
-// Provision sets up the WAF module.
 func (m *CaddyWAF) Provision(ctx caddy.Context) error {
 	m.logger = ctx.Logger(m)
 	m.logger.Info("Provisioning WAF plugin instance")
@@ -66,23 +68,25 @@ func (m *CaddyWAF) Provision(ctx caddy.Context) error {
 	}
 
 	if m.InitialCap == 0 {
-		m.logger.Info("InitialCap is not set, defaulting to 1")
 		m.InitialCap = 1
 	}
-
 	if m.MaxIdle == 0 {
-		m.logger.Info("MaxIdle is not set, defaulting to 16")
 		m.MaxIdle = 16
 	}
-
 	if m.MaxCap == 0 {
-		m.logger.Info("MaxCap is not set, defaulting to 32")
 		m.MaxCap = 32
 	}
-
-	if m.IdleTimeout == time.Duration(0)*time.Second {
-		m.logger.Info("IdleTimeout is not set, defaulting to 30 seconds")
+	if m.IdleTimeout == 0 {
 		m.IdleTimeout = 30 * time.Second
+	}
+	if m.HealthCheckInterval == 0 {
+		m.HealthCheckInterval = caddy.Duration(10 * time.Second)
+	}
+	if m.FailureThreshold == 0 {
+		m.FailureThreshold = 3
+	}
+	if m.RecoveryThreshold == 0 {
+		m.RecoveryThreshold = 2
 	}
 
 	if m.LoadBalancing != nil && m.LoadBalancing.SelectionPolicyRaw != nil {
@@ -92,8 +96,6 @@ func (m *CaddyWAF) Provision(ctx caddy.Context) error {
 		}
 		m.LoadBalancing.SelectionPolicy = mod.(Selector)
 	}
-
-	// set up load balancing
 	if m.LoadBalancing == nil {
 		m.LoadBalancing = new(LoadBalancing)
 	}
@@ -101,7 +103,6 @@ func (m *CaddyWAF) Provision(ctx caddy.Context) error {
 		m.LoadBalancing.SelectionPolicy = RandomSelection{}
 	}
 
-	// Initialize multiple engines
 	m.Engines = make(EnginePool, len(m.WafEngineAddrs))
 	for i, addr := range m.WafEngineAddrs {
 		pc := &t1k.PoolConfig{
@@ -111,34 +112,41 @@ func (m *CaddyWAF) Provision(ctx caddy.Context) error {
 			Factory:     &t1k.TcpFactory{Addr: addr},
 			IdleTimeout: m.IdleTimeout,
 		}
-
-		engine, err := initDetect(pc)
+		pool, err := t1k.NewChannelPool(pc)
 		if err != nil {
 			return fmt.Errorf("init detect error for %s: %v", addr, err)
 		}
-		m.Engines[i] = engine
+		m.Engines[i] = newEngineEntry(pool, addr)
 	}
-	m.logger.Info("WAF plugin instance Provisioned")
+
+	hcCtx, cancel := context.WithCancel(context.Background())
+	m.cancel = cancel
+	for _, e := range m.Engines {
+		e.startHealthCheck(
+			hcCtx,
+			time.Duration(m.HealthCheckInterval),
+			int32(m.FailureThreshold),
+			int32(m.RecoveryThreshold),
+			m.logger,
+		)
+	}
+
+	m.logger.Info("WAF plugin instance Provisioned",
+		zap.Strings("engine_addrs", m.WafEngineAddrs))
 	return nil
 }
 
-// ServeHTTP processes incoming HTTP requests by utilizing the Caddy WAF engine to detect
-// potential threats. If a request is identified as malicious, it redirects the request to
-// an intercept handler. Otherwise, it passes the request to the next handler in the chain.
-// The method handles detection errors and enforces a timeout for the detection process,
-// logging relevant information in each case.
 func (m CaddyWAF) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {
-
-	// choose an available WAF upstream
-	engine := m.LoadBalancing.SelectionPolicy.Select(m.Engines, r, w)
-	if engine == nil {
+	entry := m.LoadBalancing.SelectionPolicy.Select(m.Engines, r, w)
+	if entry == nil {
 		return fmt.Errorf("no available WAF engine for request %s %s", r.Method, r.URL.Path)
 	}
 
-	result, err := engine.DetectHttpRequest(r)
+	result, err := entry.engine.DetectHttpRequest(r)
 	if err != nil {
 		m.logger.Error("DetectHttpRequest error",
-			zap.String("request", r.Host),
+			zap.String("engine_addr", entry.addr),
+			zap.String("host", r.Host),
 			zap.String("path", r.URL.Path),
 			zap.String("method", r.Method),
 			zap.Error(err))
@@ -150,18 +158,21 @@ func (m CaddyWAF) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyht
 	return next.ServeHTTP(w, r)
 }
 
-// Cleans up the WAF plugin instance by closing the WAF engine and logging the cleanup process.
 func (m CaddyWAF) Cleanup() error {
-	for _, engine := range m.Engines {
-		if engine != nil {
-			engine.Release()
+	if m.cancel != nil {
+		m.cancel()
+	}
+	for _, e := range m.Engines {
+		if e != nil && e.engine != nil {
+			if cp, ok := e.engine.(interface{ Release() }); ok {
+				cp.Release()
+			}
 		}
 	}
 	m.logger.Info("Cleaning up WAF plugin instance")
 	return nil
 }
 
-// Interface guards
 var (
 	_ caddy.Provisioner           = (*CaddyWAF)(nil)
 	_ caddyhttp.MiddlewareHandler = (*CaddyWAF)(nil)

--- a/waf.go
+++ b/waf.go
@@ -131,6 +131,8 @@ func (m *CaddyWAF) Provision(ctx caddy.Context) error {
 		)
 	}
 
+	initWAFMetrics(ctx.GetMetricsRegistry())
+
 	m.logger.Info("WAF plugin instance Provisioned",
 		zap.Strings("engine_addrs", m.WafEngineAddrs))
 	return nil
@@ -139,10 +141,27 @@ func (m *CaddyWAF) Provision(ctx caddy.Context) error {
 func (m CaddyWAF) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {
 	entry := m.LoadBalancing.SelectionPolicy.Select(m.Engines, r, w)
 	if entry == nil {
+		recordRequest("error")
 		return fmt.Errorf("no available WAF engine for request %s %s", r.Method, r.URL.Path)
 	}
 
+	fr := checkFilter(r, m.SkipContentTypes, m.SkipHeader, m.MaxBodyBytes)
+	if fr == filterSkipAll {
+		recordRequest("skipped")
+		return next.ServeHTTP(w, r)
+	}
+	if fr == filterSkipBody {
+		rCopy := r.Clone(r.Context())
+		rCopy.Body = http.NoBody
+		rCopy.ContentLength = 0
+		r = rCopy
+	}
+
+	start := time.Now()
 	result, err := entry.engine.DetectHttpRequest(r)
+	elapsed := time.Since(start)
+	recordDetectDuration(elapsed.Seconds())
+
 	if err != nil {
 		m.logger.Error("DetectHttpRequest error",
 			zap.String("engine_addr", entry.addr),
@@ -150,11 +169,22 @@ func (m CaddyWAF) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyht
 			zap.String("path", r.URL.Path),
 			zap.String("method", r.Method),
 			zap.Error(err))
+		recordRequest("error")
 		return next.ServeHTTP(w, r)
 	}
+
 	if result.Blocked() {
+		if m.LogBlockedRequests {
+			m.logger.Warn("WAF blocked request",
+				zap.String("event_id", result.EventID()),
+				zap.String("remote_addr", r.RemoteAddr),
+				zap.String("path", r.URL.Path))
+		}
+		recordRequest("blocked")
 		return m.redirectIntercept(w, result)
 	}
+
+	recordRequest("allowed")
 	return next.ServeHTTP(w, r)
 }
 

--- a/waf_test.go
+++ b/waf_test.go
@@ -1,0 +1,170 @@
+package caddy_waf_t1k
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/chaitin/t1k-go/detection"
+	"go.uber.org/zap"
+
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+)
+
+type mockDetector struct {
+	result *detection.Result
+	err    error
+}
+
+func (m *mockDetector) DetectHttpRequest(_ *http.Request) (*detection.Result, error) {
+	return m.result, m.err
+}
+
+func allowedResult() *detection.Result {
+	r := &detection.Result{}
+	r.Head = '.'
+	return r
+}
+
+func blockedResult() *detection.Result {
+	r := &detection.Result{}
+	r.Head = 'X'
+	return r
+}
+
+func botResult(body []byte) *detection.Result {
+	r := &detection.Result{
+		BotQuery: []byte("challenge"),
+		BotBody:  body,
+	}
+	r.Head = '.'
+	return r
+}
+
+func makeWAF(d detector) CaddyWAF {
+	e := &engineEntry{engine: d, addr: "mock"}
+	e.healthy.Store(true)
+	return CaddyWAF{
+		logger:  zap.NewNop(),
+		Engines: EnginePool{e},
+		LoadBalancing: &LoadBalancing{
+			SelectionPolicy: RandomSelection{},
+		},
+	}
+}
+
+type handlerFunc func(http.ResponseWriter, *http.Request) error
+
+func (h handlerFunc) ServeHTTP(w http.ResponseWriter, r *http.Request) error {
+	return h(w, r)
+}
+
+func TestServeHTTP_Allowed(t *testing.T) {
+	waf := makeWAF(&mockDetector{result: allowedResult()})
+	r := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	nextCalled := false
+	next := handlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		nextCalled = true
+		return nil
+	})
+	if err := waf.ServeHTTP(w, r, next); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !nextCalled {
+		t.Fatal("next handler should be called for allowed requests")
+	}
+}
+
+func TestServeHTTP_Blocked(t *testing.T) {
+	waf := makeWAF(&mockDetector{result: blockedResult()})
+	r := httptest.NewRequest("GET", "/attack", nil)
+	w := httptest.NewRecorder()
+	next := handlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		t.Fatal("next should not be called for blocked requests")
+		return nil
+	})
+	if err := waf.ServeHTTP(w, r, next); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if w.Code != http.StatusNotImplemented {
+		t.Fatalf("expected 501, got %d", w.Code)
+	}
+}
+
+func TestServeHTTP_EngineError_FailOpen(t *testing.T) {
+	waf := makeWAF(&mockDetector{err: fmt.Errorf("connection refused")})
+	r := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	nextCalled := false
+	next := handlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		nextCalled = true
+		return nil
+	})
+	if err := waf.ServeHTTP(w, r, next); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !nextCalled {
+		t.Fatal("next handler should be called when engine errors (fail-open)")
+	}
+}
+
+func TestServeHTTP_BotDetected_WritesBodyAndSkipsNext(t *testing.T) {
+	waf := makeWAF(&mockDetector{result: botResult([]byte(`<html>challenge</html>`))})
+	waf.BotDetect = true
+	r := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	next := handlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		t.Fatal("next should not be called for bot challenge")
+		return nil
+	})
+	if err := waf.ServeHTTP(w, r, next); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if w.Body.String() != `<html>challenge</html>` {
+		t.Fatalf("expected bot body, got %s", w.Body.String())
+	}
+}
+
+func TestServeHTTP_BotDetect_Disabled_PassesThrough(t *testing.T) {
+	waf := makeWAF(&mockDetector{result: botResult([]byte("challenge"))})
+	waf.BotDetect = false
+	r := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	nextCalled := false
+	next := handlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		nextCalled = true
+		return nil
+	})
+	if err := waf.ServeHTTP(w, r, next); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !nextCalled {
+		t.Fatal("with bot_detect off, BotDetected result should fall through to normal allow/block logic")
+	}
+}
+
+func TestServeHTTP_SkipFilter_CallsNext(t *testing.T) {
+	waf := makeWAF(&mockDetector{result: blockedResult()})
+	waf.SkipHeader = "X-Skip"
+	r := httptest.NewRequest("GET", "/", nil)
+	r.Header.Set("X-Skip", "1")
+	w := httptest.NewRecorder()
+	nextCalled := false
+	next := handlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		nextCalled = true
+		return nil
+	})
+	if err := waf.ServeHTTP(w, r, next); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !nextCalled {
+		t.Fatal("skipped request should bypass detection and call next")
+	}
+}
+
+var _ caddyhttp.Handler = handlerFunc(nil)


### PR DESCRIPTION
## Summary

- **Batch 1 — Health check & failover**: Each WAF engine entry now wraps a `detector` interface with atomic health state (`healthy`, `failCount`, `okCount`). A TCP dial probe goroutine marks engines unhealthy after `failure_threshold` consecutive failures and recovers after `recovery_threshold` consecutive successes. Load balancing filters to healthy engines first; fails-open (returns full pool) when all are down. Goroutine lifecycle managed by `context.WithCancel` in `Provision`/`Cleanup`.

- **Batch 2 — Request filtering & Prometheus metrics**: Requests can be skipped by Content-Type prefix, header presence, or body size (`skip_content_types`, `skip_header`, `max_body_size`). Oversized bodies are stripped before detection (headers still inspected). Prometheus counters/histogram/gauge exposed via `caddy.GetMetricsRegistry()`: `waf_requests_total{result}`, `waf_detect_duration_seconds`, `waf_engine_healthy{addr}`.

- **Batch 3 — Bot detection & unit tests**: When `bot_detect on`, a `BotDetected()` result writes `BotBody` (200 OK) directly to the client and strips SafeLine internal cookies (`sl_xxx_ug_to` etc.) before they reach the upstream. 23 unit tests added covering health state machine, filter edge cases, load balancer health filtering, and `ServeHTTP` golden paths.

## New Caddyfile options

```
waf_chaitin {
    waf_engine_addr 10.0.0.1:8000 10.0.0.2:8000

    # Batch 1
    health_check_interval 10s
    failure_threshold     3
    recovery_threshold    2

    # Batch 2
    skip_content_types image/jpeg image/png application/octet-stream
    skip_header        X-Internal-Token
    max_body_size      1MB
    log_blocked_requests off

    # Batch 3
    bot_detect off
}
```

## Test plan

- [ ] `go test ./...` — 23 tests, all pass
- [ ] `xcaddy build` — binary registers `http.handlers.waf_chaitin`, `http.waf_chaitin.selection_policies.random`, `http.waf_chaitin.selection_policies.round_robin`
- [ ] Engine restart: mark engine unhealthy after `failure_threshold` failures, recover after `recovery_threshold` successes, fail-open when all down
- [ ] `skip_header` / `skip_content_types` bypass: confirm skipped requests never reach WAF engine
- [ ] `bot_detect on`: BotBody written to client, SafeLine cookies stripped from upstream request

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Engine health monitoring with automatic failover when engines become unavailable
  * Request filtering capabilities (skip by content type, custom header, or body size threshold)
  * Bot detection with automatic cookie stripping
  * Prometheus metrics for tracking request outcomes and engine health status

* **Refactor**
  * Load balancing updated to prioritize healthy engines during selection

* **Chores**
  * Updated module dependencies and `.gitignore` configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->