### PR TITLE
feat: add passive health check, Prometheus metrics, and code quality improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,102 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What This Project Is
+
+A [Caddy Server](https://github.com/caddyserver/caddy) plugin that integrates [Chaitin SafeLine](https://github.com/chaitin/SafeLine) as a WAF backend engine. HTTP requests are forwarded to one or more t1k engine instances over TCP for threat detection; blocked requests receive an intercept response.
+
+## Build Commands
+
+This plugin cannot be built with `go build` directly — Caddy plugins must be compiled via `xcaddy`:
+
+```bash
+# Install xcaddy first
+go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
+
+# Build a Caddy binary with this plugin embedded
+xcaddy build \
+  --with github.com/W0n9/caddy_waf_t1k \
+  --replace github.com/chaitin/t1k-go=github.com/w0n9/t1k-go@latest
+
+# Build from local checkout (development)
+xcaddy build \
+  --with github.com/W0n9/caddy_waf_t1k=. \
+  --replace github.com/chaitin/t1k-go=github.com/w0n9/t1k-go@latest \
+  --output ./build/caddy
+```
+
+## Test / Lint Commands
+
+```bash
+# Compile check (no real unit tests exist yet)
+go test ./...
+
+# Verify module consistency
+go mod tidy
+go mod verify
+```
+
+## Repository Layout Notes
+
+- Root module is the Caddy plugin; `src/t1k-go`, `src/caddy`, and `src/xcaddy` are adjacent source checkouts for local dependency/reference work, not plugin packages.
+- Local development/testing should prefer the local `src/t1k-go` checkout; if a remote `t1k-go` tag is needed, ask the human which tag to use instead of hard-coding one.
+- `go test ./...` is a compile check only; request detection behavior requires a reachable SafeLine/t1k engine at each `waf_engine_addr`.
+
+## Architecture
+
+Four source files form the entire plugin:
+
+| File | Responsibility |
+|------|---------------|
+| `waf.go` | Module registration, `Engine` wrapper struct, `Provision` (pool init), `ServeHTTP` (detect + block + metrics), `Cleanup`, error classification (`isEngineError`), passive health check (`countFailure`) |
+| `caddyfile.go` | Caddyfile directive parsing (`waf_chaitin { ... }`) |
+| `load_balancer.go` | `Selector` interface + `RandomSelection` / `RoundRobinSelection` implementations (skip unhealthy engines) |
+| `rule.go` | `redirectIntercept` — writes the block response when a request is flagged |
+| `metrics.go` | Prometheus metrics registration and engine health gauge updater |
+
+**Request flow:**  
+`ServeHTTP` → pick engine via `LoadBalancing.SelectionPolicy.Select(m.Engines, r, w)` (skips unhealthy engines) → if all engines unavailable, fail-open → `engine.DetectHttpRequest(r)` → if error, classify via `isEngineError()`: engine errors trigger `countFailure()` (logged as error), client errors are logged as warn; both fail-open → if `result.Blocked()` call `redirectIntercept`, else call `next.ServeHTTP`.
+
+**Error classification:**  
+`isEngineError()` distinguishes client-side errors (H3_REQUEST_CANCELLED, client disconnected, keepalive limit, connection reset by peer, etc.) from engine-side errors (connection refused, dial timeout, broken pipe). Only engine errors count toward health check failures.
+
+**Passive health check (Caddy-style):**  
+On engine error, `countFailure()` atomically increments the engine's fail counter and spawns a goroutine that decrements it after `health_fail_duration`. When `fails >= health_max_fails`, the engine is marked unavailable and skipped by selection policies. Setting `health_fail_duration` to 0 (default) disables health checking entirely.
+
+**Intercept response:**  
+Blocked requests set `Content-Type: application/json`, `X-Event-ID`, return HTTP 501, and write `{"message":"Intercept illegal requests","event_id":"..."}` JSON from `redirectIntercept`.
+
+**Prometheus metrics:**  
+- `caddy_waf_requests_total{action}` — counter (blocked/passed/error/failopen)
+- `caddy_waf_detect_duration_seconds{engine}` — histogram
+- `caddy_waf_engines_healthy{engine}` — gauge (1=healthy, 0=unhealthy), updated every 10s
+
+**Engine pool:**  
+Each address in `waf_engine_addrs` gets its own `t1k.ChannelPool` (a TCP connection pool to one SafeLine engine). The pool settings (`initial_cap`, `max_idle`, `max_cap`, `idle_timeout`) are shared across all pools.
+
+## Important: Module Replace Directive
+
+`go.mod` replaces the upstream `github.com/chaitin/t1k-go` with a fork `github.com/w0n9/t1k-go`. This must be carried through in every `xcaddy build` call via `--replace github.com/chaitin/t1k-go=github.com/w0n9/t1k-go@latest`. Forgetting this flag causes a build failure.
+
+## Caddyfile Configuration Reference
+
+```caddyfile
+waf_chaitin {
+    waf_engine_addr 169.254.0.5:8000 169.254.0.6:8000  # one or more IP:port
+    initial_cap 1      # initial connections per pool
+    max_idle 16        # max idle connections per pool
+    max_cap 32         # max total connections per pool
+    idle_timeout 30s   # duration string (e.g. 30s, 1m) — NOT bare integer
+    lb_policy round_robin  # optional; default is random
+    health_fail_duration 30s  # passive health check window; 0 = disabled (default)
+    health_max_fails 3        # failure threshold to mark engine unhealthy (default: 1)
+}
+```
+
+## Caddy Module IDs
+
+- Handler: `http.handlers.waf_chaitin`
+- Selection policies namespace: `http.waf_chaitin.selection_policies`
+  - `http.waf_chaitin.selection_policies.random`
+  - `http.waf_chaitin.selection_policies.round_robin`

--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ This is a WAF plugin for [Caddy Server](https://github.com/caddyserver/caddy) us
 			initial_cap 1 # initial connection of the engine
 			max_idle 16 # max idle connections
 			max_cap 32 # max connections
-			idle_timeout 30 # connections idle timeout
+			idle_timeout 30s # connections idle timeout
+			lb_policy round_robin # load balancing policy (random or round_robin, default: random)
+			health_fail_duration 30s # passive health check window (default: 0 = disabled)
+			health_max_fails 3 # failure threshold to mark engine unhealthy (default: 1)
 		}
 	}
 }
@@ -27,7 +30,7 @@ This is a WAF plugin for [Caddy Server](https://github.com/caddyserver/caddy) us
 # How to build
 
 ```
-xcaddy build --with github.com/W0n9/caddy_waf_t1k
+xcaddy build --with github.com/W0n9/caddy_waf_t1k --replace github.com/chaitin/t1k-go=github.com/w0n9/t1k-go@latest
 ```
 
 # TODO

--- a/caddyfile.go
+++ b/caddyfile.go
@@ -98,6 +98,24 @@ func (m *CaddyWAF) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				m.LoadBalancing = new(LoadBalancing)
 			}
 			m.LoadBalancing.SelectionPolicyRaw = caddyconfig.JSONModuleObject(sel, "policy", name, nil)
+		case "health_fail_duration":
+			if !d.NextArg() {
+				return d.ArgErr()
+			}
+			dur, err := caddy.ParseDuration(d.Val())
+			if err != nil {
+				return d.Errf("invalid health_fail_duration value: %v", err)
+			}
+			m.HealthFailDuration = caddy.Duration(dur)
+		case "health_max_fails":
+			if !d.NextArg() {
+				return d.ArgErr()
+			}
+			maxFails, err := strconv.Atoi(d.Val())
+			if err != nil {
+				return d.Errf("invalid health_max_fails value: %v", err)
+			}
+			m.HealthMaxFails = maxFails
 		default:
 			return d.Errf("unrecognized subdirective %s", d.Val())
 		}
@@ -118,5 +136,5 @@ func (m *CaddyWAF) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 func parseCaddyfileHandler(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error) {
 	var m CaddyWAF
 	err := m.UnmarshalCaddyfile(h.Dispenser)
-	return m, err
+	return &m, err
 }

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,13 @@
 module github.com/W0n9/caddy_waf_t1k
 
-go 1.25.0
+go 1.26.0
 
 replace github.com/chaitin/t1k-go => github.com/w0n9/t1k-go v1.5.8
 
 require (
 	github.com/caddyserver/caddy/v2 v2.11.2
 	github.com/chaitin/t1k-go v0.0.0-00010101000000-000000000000
+	github.com/prometheus/client_golang v1.23.2
 	go.uber.org/zap v1.27.1
 )
 
@@ -74,7 +75,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect

--- a/load_balancer.go
+++ b/load_balancer.go
@@ -2,13 +2,12 @@ package caddy_waf_t1k
 
 import (
 	"encoding/json"
-	weakrand "math/rand"
+	weakrand "math/rand/v2"
 	"net/http"
 	"sync/atomic"
 
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
-	"github.com/chaitin/t1k-go"
 )
 
 func init() {
@@ -27,7 +26,7 @@ type LoadBalancing struct {
 
 // Selector selects an available upstream from the pool.
 type Selector interface {
-	Select(EnginePool, *http.Request, http.ResponseWriter) *t1k.ChannelPool
+	Select(EnginePool, *http.Request, http.ResponseWriter) *Engine
 }
 
 // RandomSelection is a policy that selects
@@ -43,7 +42,7 @@ func (RandomSelection) CaddyModule() caddy.ModuleInfo {
 }
 
 // Select returns an available host, if any.
-func (r RandomSelection) Select(pool EnginePool, request *http.Request, _ http.ResponseWriter) *t1k.ChannelPool {
+func (r RandomSelection) Select(pool EnginePool, request *http.Request, _ http.ResponseWriter) *Engine {
 	return selectRandomHost(pool)
 }
 
@@ -57,14 +56,15 @@ func (r *RandomSelection) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 }
 
 // selectRandomHost returns a random available host
-func selectRandomHost(pool []*t1k.ChannelPool) *t1k.ChannelPool {
-	// use reservoir sampling because the number of available
-	// hosts isn't known: https://en.wikipedia.org/wiki/Reservoir_sampling
-	var randomHost *t1k.ChannelPool
+func selectRandomHost(pool []*Engine) *Engine {
+	var randomHost *Engine
 	var count int
 	for _, upstream := range pool {
+		if !upstream.Available() {
+			continue
+		}
 		count++
-		if (weakrand.Int() % count) == 0 { //nolint:gosec
+		if weakrand.IntN(count) == 0 { //nolint:gosec
 			randomHost = upstream
 		}
 	}
@@ -86,14 +86,19 @@ func (RoundRobinSelection) CaddyModule() caddy.ModuleInfo {
 }
 
 // Select returns an available host, if any.
-func (r *RoundRobinSelection) Select(pool EnginePool, _ *http.Request, _ http.ResponseWriter) *t1k.ChannelPool {
+func (r *RoundRobinSelection) Select(pool EnginePool, _ *http.Request, _ http.ResponseWriter) *Engine {
 	n := uint32(len(pool))
 	if n == 0 {
 		return nil
 	}
 	robin := atomic.AddUint32(&r.robin, 1)
-	host := pool[robin%n]
-	return host
+	for i := range n {
+		host := pool[(robin+i)%n]
+		if host.Available() {
+			return host
+		}
+	}
+	return nil
 }
 
 // UnmarshalCaddyfile sets up the module from Caddyfile tokens.

--- a/metrics.go
+++ b/metrics.go
@@ -1,0 +1,111 @@
+package caddy_waf_t1k
+
+import (
+	"errors"
+	"runtime/debug"
+	"sync"
+	"time"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+var wafMetrics = struct {
+	once            sync.Once
+	requestsTotal   *prometheus.CounterVec
+	detectDuration  *prometheus.HistogramVec
+	enginesHealthy  *prometheus.GaugeVec
+}{}
+
+func initWAFMetrics(registry *prometheus.Registry) {
+	const ns, sub = "caddy", "waf"
+
+	wafMetrics.once.Do(func() {
+		wafMetrics.requestsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: ns,
+			Subsystem: sub,
+			Name:      "requests_total",
+			Help:      "Total number of requests processed by the WAF.",
+		}, []string{"action"})
+
+		wafMetrics.detectDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: ns,
+			Subsystem: sub,
+			Name:      "detect_duration_seconds",
+			Help:      "Duration of WAF detection requests.",
+			Buckets:   prometheus.DefBuckets,
+		}, []string{"engine"})
+
+		wafMetrics.enginesHealthy = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: ns,
+			Subsystem: sub,
+			Name:      "engines_healthy",
+			Help:      "Health status of WAF engines.",
+		}, []string{"engine"})
+	})
+
+	for _, collector := range []prometheus.Collector{
+		wafMetrics.requestsTotal,
+		wafMetrics.detectDuration,
+		wafMetrics.enginesHealthy,
+	} {
+		if err := registry.Register(collector); err != nil &&
+			!errors.As(err, &prometheus.AlreadyRegisteredError{}) {
+			panic(err)
+		}
+	}
+}
+
+type metricsEnginesHealthyUpdater struct {
+	engines EnginePool
+	ctx     caddy.Context
+	logger  *zap.Logger
+}
+
+func newMetricsEnginesHealthyUpdater(m *CaddyWAF) *metricsEnginesHealthyUpdater {
+	return &metricsEnginesHealthyUpdater{
+		engines: m.Engines,
+		ctx:     m.ctx,
+		logger:  m.logger.Named("waf.metrics"),
+	}
+}
+
+func (u *metricsEnginesHealthyUpdater) start() {
+	go func() {
+		defer func() {
+			if err := recover(); err != nil {
+				if c := u.logger.Check(zapcore.ErrorLevel, "engines healthy metrics updater panicked"); c != nil {
+					c.Write(
+						zap.Any("error", err),
+						zap.ByteString("stack", debug.Stack()),
+					)
+				}
+			}
+		}()
+
+		u.update()
+
+		ticker := time.NewTicker(10 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				u.update()
+			case <-u.ctx.Done():
+				return
+			}
+		}
+	}()
+}
+
+func (u *metricsEnginesHealthyUpdater) update() {
+	for _, engine := range u.engines {
+		val := 0.0
+		if engine.Available() {
+			val = 1.0
+		}
+		wafMetrics.enginesHealthy.With(prometheus.Labels{"engine": engine.addr}).Set(val)
+	}
+}

--- a/metrics.go
+++ b/metrics.go
@@ -46,14 +46,27 @@ func initWAFMetrics(registry *prometheus.Registry) {
 		}, []string{"engine"})
 	})
 
-	for _, collector := range []prometheus.Collector{
-		wafMetrics.requestsTotal,
-		wafMetrics.detectDuration,
-		wafMetrics.enginesHealthy,
+	logger := caddy.Log().Named("waf.metrics")
+	for _, metric := range []struct {
+		name      string
+		collector prometheus.Collector
+	}{
+		{name: "requests_total", collector: wafMetrics.requestsTotal},
+		{name: "detect_duration_seconds", collector: wafMetrics.detectDuration},
+		{name: "engines_healthy", collector: wafMetrics.enginesHealthy},
 	} {
-		if err := registry.Register(collector); err != nil &&
-			!errors.As(err, &prometheus.AlreadyRegisteredError{}) {
-			panic(err)
+		if err := registry.Register(metric.collector); err != nil {
+			var alreadyRegisteredErr prometheus.AlreadyRegisteredError
+			if errors.As(err, &alreadyRegisteredErr) {
+				continue
+			}
+
+			if c := logger.Check(zap.WarnLevel, "failed to register WAF metric collector"); c != nil {
+				c.Write(
+					zap.String("metric", metric.name),
+					zap.Error(err),
+				)
+			}
 		}
 	}
 }

--- a/rule.go
+++ b/rule.go
@@ -11,9 +11,10 @@ import (
 // redirectIntercept Intercept request
 func (m *CaddyWAF) redirectIntercept(w http.ResponseWriter, result *detection.Result) error {
 	// var tpl *template.Template
+	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("X-Event-ID", result.EventID())
 	w.WriteHeader(http.StatusNotImplemented)
-	BlockMessage := map[string]interface{}{
+	BlockMessage := map[string]any{
 		"message":  "Intercept illegal requests",
 		"event_id": result.EventID(),
 	}

--- a/waf.go
+++ b/waf.go
@@ -3,9 +3,12 @@ package caddy_waf_t1k
 import (
 	"fmt"
 	"net/http"
+	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/chaitin/t1k-go"
+	"github.com/chaitin/t1k-go/detection"
 
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
@@ -18,11 +21,39 @@ func init() {
 	caddy.RegisterModule(CaddyWAF{})
 }
 
-type EnginePool []*t1k.ChannelPool
+// Engine wraps a t1k.ChannelPool with per-engine health state.
+type Engine struct {
+	pool     *t1k.ChannelPool
+	addr     string
+	fails    int64 // atomic: unexpired failure count
+	maxFails int
+}
+
+func (e *Engine) DetectHttpRequest(r *http.Request) (*detection.Result, error) {
+	return e.pool.DetectHttpRequest(r)
+}
+
+func (e *Engine) Fails() int {
+	return int(atomic.LoadInt64(&e.fails))
+}
+
+func (e *Engine) countFail(delta int) {
+	atomic.AddInt64(&e.fails, int64(delta))
+}
+
+func (e *Engine) Available() bool {
+	if e.maxFails <= 0 {
+		return true
+	}
+	return e.Fails() < e.maxFails
+}
+
+type EnginePool []*Engine
 
 // CaddyWAF implements an HTTP handler for WAF.
 type CaddyWAF struct {
 	logger *zap.Logger
+	ctx    caddy.Context
 
 	WafEngineAddrs []string `json:"waf_engine_addrs,omitempty"` // WAF Engine address, expects a URL or IP address
 
@@ -32,11 +63,13 @@ type CaddyWAF struct {
 	// Load balancing distributes load/requests between backends.
 	LoadBalancing *LoadBalancing `json:"load_balancing,omitempty"`
 
-	InitialCap  int           `json:"initial_cap,omitempty"`  // InitialCap is the initial capacity of the pool
-	MaxIdle     int           `json:"max_idle,omitempty"`     // MaxIdle is the maximum number of idle connections in the pool
-	MaxCap      int           `json:"max_cap,omitempty"`      // MaxCap is the maximum capacity of the pool
-	IdleTimeout time.Duration `json:"idle_timeout,omitempty"` // IdleTimeout is the duration after which an idle connection is closed
-	// block_tpl_path string `json:"block_tpl_path"` // Block template path
+	InitialCap  int           `json:"initial_cap,omitempty"`
+	MaxIdle     int           `json:"max_idle,omitempty"`
+	MaxCap      int           `json:"max_cap,omitempty"`
+	IdleTimeout time.Duration `json:"idle_timeout,omitempty"`
+
+	HealthFailDuration caddy.Duration `json:"health_fail_duration,omitempty"`
+	HealthMaxFails     int            `json:"health_max_fails,omitempty"`
 }
 
 // CaddyModule returns the Caddy module information.
@@ -59,6 +92,7 @@ func initDetect(pc *t1k.PoolConfig) (*t1k.ChannelPool, error) {
 // Provision sets up the WAF module.
 func (m *CaddyWAF) Provision(ctx caddy.Context) error {
 	m.logger = ctx.Logger(m)
+	m.ctx = ctx
 	m.logger.Info("Provisioning WAF plugin instance")
 
 	if len(m.WafEngineAddrs) == 0 {
@@ -101,6 +135,10 @@ func (m *CaddyWAF) Provision(ctx caddy.Context) error {
 		m.LoadBalancing.SelectionPolicy = RandomSelection{}
 	}
 
+	if m.HealthMaxFails == 0 {
+		m.HealthMaxFails = 1
+	}
+
 	// Initialize multiple engines
 	m.Engines = make(EnginePool, len(m.WafEngineAddrs))
 	for i, addr := range m.WafEngineAddrs {
@@ -116,9 +154,17 @@ func (m *CaddyWAF) Provision(ctx caddy.Context) error {
 		if err != nil {
 			return fmt.Errorf("init detect error for %s: %v", addr, err)
 		}
-		m.Engines[i] = engine
+		m.Engines[i] = &Engine{
+			pool:     engine,
+			addr:     addr,
+			maxFails: m.HealthMaxFails,
+		}
 	}
 	m.logger.Info("WAF plugin instance Provisioned")
+
+	initWAFMetrics(ctx.GetMetricsRegistry())
+	newMetricsEnginesHealthyUpdater(m).start()
+
 	return nil
 }
 
@@ -127,43 +173,97 @@ func (m *CaddyWAF) Provision(ctx caddy.Context) error {
 // an intercept handler. Otherwise, it passes the request to the next handler in the chain.
 // The method handles detection errors and enforces a timeout for the detection process,
 // logging relevant information in each case.
-func (m CaddyWAF) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {
-
-	// choose an available WAF upstream
+func (m *CaddyWAF) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyhttp.Handler) error {
 	engine := m.LoadBalancing.SelectionPolicy.Select(m.Engines, r, w)
 	if engine == nil {
-		return fmt.Errorf("no available WAF engine for request %s %s", r.Method, r.URL.Path)
+		m.logger.Warn("all WAF engines unavailable, request passed through",
+			zap.String("path", r.URL.Path),
+			zap.String("method", r.Method))
+		wafMetrics.requestsTotal.WithLabelValues("failopen").Inc()
+		return next.ServeHTTP(w, r)
 	}
 
+	start := time.Now()
 	result, err := engine.DetectHttpRequest(r)
+	wafMetrics.detectDuration.WithLabelValues(engine.addr).Observe(time.Since(start).Seconds())
+
 	if err != nil {
-		m.logger.Error("DetectHttpRequest error",
-			zap.String("request", r.Host),
-			zap.String("path", r.URL.Path),
-			zap.String("method", r.Method),
-			zap.Error(err))
+		wafMetrics.requestsTotal.WithLabelValues("error").Inc()
+		if isEngineError(err) {
+			m.logger.Error("DetectHttpRequest engine error",
+				zap.String("engine", engine.addr),
+				zap.String("request", r.Host),
+				zap.String("path", r.URL.Path),
+				zap.String("method", r.Method),
+				zap.Error(err))
+			m.countFailure(engine)
+		} else {
+			m.logger.Warn("DetectHttpRequest client error",
+				zap.String("request", r.Host),
+				zap.String("path", r.URL.Path),
+				zap.String("method", r.Method),
+				zap.Error(err))
+		}
 		return next.ServeHTTP(w, r)
 	}
 	if result.Blocked() {
+		wafMetrics.requestsTotal.WithLabelValues("blocked").Inc()
 		return m.redirectIntercept(w, result)
 	}
+	wafMetrics.requestsTotal.WithLabelValues("passed").Inc()
 	return next.ServeHTTP(w, r)
 }
 
 // Cleans up the WAF plugin instance by closing the WAF engine and logging the cleanup process.
-func (m CaddyWAF) Cleanup() error {
+func (m *CaddyWAF) Cleanup() error {
 	for _, engine := range m.Engines {
 		if engine != nil {
-			engine.Release()
+			engine.pool.Release()
 		}
 	}
 	m.logger.Info("Cleaning up WAF plugin instance")
 	return nil
 }
 
+var clientErrorPatterns = []string{
+	"H3_REQUEST_CANCELLED",
+	"H3 error",
+	"client disconnected",
+	"keepalive limit reached",
+	"connection reset by peer",
+	"timeout: no recent network activity",
+	"empty hex number for chunk length",
+	"context canceled",
+	"request canceled",
+}
+
+func isEngineError(err error) bool {
+	msg := err.Error()
+	for _, pattern := range clientErrorPatterns {
+		if strings.Contains(msg, pattern) {
+			return false
+		}
+	}
+	return true
+}
+
+func (m *CaddyWAF) countFailure(engine *Engine) {
+	failDuration := time.Duration(m.HealthFailDuration)
+	if failDuration == 0 {
+		return
+	}
+	engine.countFail(1)
+	go func() {
+		timer := time.NewTimer(failDuration)
+		<-timer.C
+		engine.countFail(-1)
+	}()
+}
+
 // Interface guards
 var (
 	_ caddy.Provisioner           = (*CaddyWAF)(nil)
+	_ caddy.CleanerUpper          = (*CaddyWAF)(nil)
 	_ caddyhttp.MiddlewareHandler = (*CaddyWAF)(nil)
 	_ caddyfile.Unmarshaler       = (*CaddyWAF)(nil)
 )

--- a/waf_test.go
+++ b/waf_test.go
@@ -1,0 +1,242 @@
+package caddy_waf_t1k
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/caddyserver/caddy/v2"
+)
+
+func TestIsEngineError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{"connection refused is engine error", errors.New("dial tcp 10.0.0.1:8000: connect: connection refused"), true},
+		{"dial timeout is engine error", errors.New("dial tcp 10.0.0.1:8000: i/o timeout"), true},
+		{"broken pipe is engine error", errors.New("write: broken pipe"), true},
+		{"unknown error is engine error", errors.New("something unexpected"), true},
+
+		{"H3 request cancelled is client error", errors.New("H3_REQUEST_CANCELLED"), false},
+		{"H3 error is client error", errors.New("H3 error (0x0)"), false},
+		{"client disconnected is client error", errors.New("client disconnected"), false},
+		{"keepalive limit is client error", errors.New("NO_ERROR (remote): keepalive limit reached"), false},
+		{"connection reset by peer is client error", errors.New("read tcp 1.2.3.4:443->5.6.7.8:12345: read: connection reset by peer"), false},
+		{"QUIC idle timeout is client error", errors.New("timeout: no recent network activity"), false},
+		{"chunked encoding error is client error", errors.New("empty hex number for chunk length"), false},
+		{"context canceled is client error", errors.New("context canceled"), false},
+		{"request canceled is client error", errors.New("request canceled"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isEngineError(tt.err)
+			if got != tt.expected {
+				t.Errorf("isEngineError(%q) = %v, want %v", tt.err, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestEngineAvailable(t *testing.T) {
+	t.Run("always available when maxFails is 0", func(t *testing.T) {
+		e := &Engine{maxFails: 0}
+		atomic.StoreInt64(&e.fails, 100)
+		if !e.Available() {
+			t.Error("expected Available() = true when maxFails is 0")
+		}
+	})
+
+	t.Run("available when fails below threshold", func(t *testing.T) {
+		e := &Engine{maxFails: 3}
+		atomic.StoreInt64(&e.fails, 2)
+		if !e.Available() {
+			t.Error("expected Available() = true when fails < maxFails")
+		}
+	})
+
+	t.Run("unavailable when fails at threshold", func(t *testing.T) {
+		e := &Engine{maxFails: 3}
+		atomic.StoreInt64(&e.fails, 3)
+		if e.Available() {
+			t.Error("expected Available() = false when fails >= maxFails")
+		}
+	})
+
+	t.Run("unavailable when fails above threshold", func(t *testing.T) {
+		e := &Engine{maxFails: 3}
+		atomic.StoreInt64(&e.fails, 5)
+		if e.Available() {
+			t.Error("expected Available() = false when fails > maxFails")
+		}
+	})
+}
+
+func TestEngineCountFail(t *testing.T) {
+	e := &Engine{}
+
+	e.countFail(1)
+	if got := e.Fails(); got != 1 {
+		t.Errorf("after countFail(1): Fails() = %d, want 1", got)
+	}
+
+	e.countFail(1)
+	if got := e.Fails(); got != 2 {
+		t.Errorf("after second countFail(1): Fails() = %d, want 2", got)
+	}
+
+	e.countFail(-1)
+	if got := e.Fails(); got != 1 {
+		t.Errorf("after countFail(-1): Fails() = %d, want 1", got)
+	}
+}
+
+func TestSelectRandomHostSkipsUnhealthy(t *testing.T) {
+	healthy := &Engine{addr: "healthy", maxFails: 1}
+	unhealthy := &Engine{addr: "unhealthy", maxFails: 1}
+	atomic.StoreInt64(&unhealthy.fails, 1)
+
+	pool := []*Engine{unhealthy, healthy}
+
+	for range 100 {
+		got := selectRandomHost(pool)
+		if got == nil {
+			t.Fatal("selectRandomHost returned nil with available engines")
+		}
+		if got.addr == "unhealthy" {
+			t.Fatal("selectRandomHost selected unhealthy engine")
+		}
+	}
+}
+
+func TestSelectRandomHostReturnsNilWhenAllUnhealthy(t *testing.T) {
+	e1 := &Engine{addr: "e1", maxFails: 1}
+	e2 := &Engine{addr: "e2", maxFails: 1}
+	atomic.StoreInt64(&e1.fails, 1)
+	atomic.StoreInt64(&e2.fails, 1)
+
+	got := selectRandomHost([]*Engine{e1, e2})
+	if got != nil {
+		t.Errorf("expected nil when all engines unhealthy, got %s", got.addr)
+	}
+}
+
+func TestRoundRobinSkipsUnhealthy(t *testing.T) {
+	healthy := &Engine{addr: "healthy", maxFails: 1}
+	unhealthy := &Engine{addr: "unhealthy", maxFails: 1}
+	atomic.StoreInt64(&unhealthy.fails, 1)
+
+	rr := &RoundRobinSelection{}
+	pool := EnginePool{unhealthy, healthy}
+
+	for range 10 {
+		got := rr.Select(pool, nil, nil)
+		if got == nil {
+			t.Fatal("RoundRobin returned nil with available engines")
+		}
+		if got.addr == "unhealthy" {
+			t.Fatal("RoundRobin selected unhealthy engine")
+		}
+	}
+}
+
+func TestRoundRobinReturnsNilWhenAllUnhealthy(t *testing.T) {
+	e1 := &Engine{addr: "e1", maxFails: 1}
+	e2 := &Engine{addr: "e2", maxFails: 1}
+	atomic.StoreInt64(&e1.fails, 1)
+	atomic.StoreInt64(&e2.fails, 1)
+
+	rr := &RoundRobinSelection{}
+	got := rr.Select(EnginePool{e1, e2}, nil, nil)
+	if got != nil {
+		t.Errorf("expected nil when all engines unhealthy, got %s", got.addr)
+	}
+}
+
+func TestRoundRobinDistribution(t *testing.T) {
+	e1 := &Engine{addr: "e1", maxFails: 0}
+	e2 := &Engine{addr: "e2", maxFails: 0}
+	e3 := &Engine{addr: "e3", maxFails: 0}
+
+	rr := &RoundRobinSelection{}
+	pool := EnginePool{e1, e2, e3}
+
+	counts := map[string]int{}
+	for range 30 {
+		got := rr.Select(pool, nil, nil)
+		counts[got.addr]++
+	}
+
+	for _, addr := range []string{"e1", "e2", "e3"} {
+		if counts[addr] != 10 {
+			t.Errorf("expected 10 selections for %s, got %d", addr, counts[addr])
+		}
+	}
+}
+
+func TestSelectRandomHostEmptyPool(t *testing.T) {
+	got := selectRandomHost([]*Engine{})
+	if got != nil {
+		t.Error("expected nil for empty pool")
+	}
+}
+
+func TestCountFailureDisabledWhenZeroDuration(t *testing.T) {
+	m := &CaddyWAF{HealthFailDuration: 0}
+	e := &Engine{maxFails: 1}
+
+	m.countFailure(e)
+
+	if got := e.Fails(); got != 0 {
+		t.Errorf("countFailure should be no-op when HealthFailDuration=0, got Fails()=%d", got)
+	}
+}
+
+func TestCountFailureIncrementsAndDecrements(t *testing.T) {
+	m := &CaddyWAF{HealthFailDuration: caddy.Duration(100 * time.Millisecond)}
+	e := &Engine{maxFails: 3}
+
+	m.countFailure(e)
+	if got := e.Fails(); got != 1 {
+		t.Errorf("after countFailure: Fails() = %d, want 1", got)
+	}
+
+	m.countFailure(e)
+	if got := e.Fails(); got != 2 {
+		t.Errorf("after second countFailure: Fails() = %d, want 2", got)
+	}
+
+	// Wait for timers to expire
+	time.Sleep(200 * time.Millisecond)
+
+	if got := e.Fails(); got != 0 {
+		t.Errorf("after timer expiry: Fails() = %d, want 0", got)
+	}
+}
+
+func TestCountFailureEngineBecomesAvailableAfterExpiry(t *testing.T) {
+	m := &CaddyWAF{HealthFailDuration: caddy.Duration(100 * time.Millisecond)}
+	e := &Engine{maxFails: 1}
+
+	m.countFailure(e)
+	if e.Available() {
+		t.Error("engine should be unavailable after failure")
+	}
+
+	time.Sleep(200 * time.Millisecond)
+
+	if !e.Available() {
+		t.Error("engine should be available after timer expiry")
+	}
+}
+
+func TestRoundRobinEmptyPool(t *testing.T) {
+	rr := &RoundRobinSelection{}
+	got := rr.Select(EnginePool{}, nil, nil)
+	if got != nil {
+		t.Error("expected nil for empty pool")
+	}
+}


### PR DESCRIPTION
## Summary

- **被动健康检查**：基于 Caddy reverse_proxy 的 countFailure 模式，引擎错误触发失败计数，超过阈值后自动跳过，定时器过期后恢复
- **错误分类**：区分客户端错误（H3_REQUEST_CANCELLED、client disconnected 等）和引擎错误（connection refused、dial timeout 等），客户端错误降为 warn 级别
- **Prometheus Metrics**：caddy_waf_requests_total（blocked/passed/error/failopen）、caddy_waf_detect_duration_seconds、caddy_waf_engines_healthy
- **代码质量修复**：Content-Type header、值接收者→指针接收者、math/rand/v2、Go 1.26
- **13 个单元测试**覆盖错误分类、健康检查、负载均衡

## New Caddyfile Directives

```caddyfile
health_fail_duration 30s  # passive health check window (default: 0 = disabled)
health_max_fails 3        # failure threshold (default: 1)
```

## Test Plan

- [x] `go test ./...` — 13 tests passing
- [x] `go vet ./...` — clean
- [x] xcaddy build — successful
- [x] Smoke test with real t1k engine: normal request → 200, SQL injection → 501
- [x] Prometheus metrics endpoint verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Passive health checking for WAF engines with configurable fail thresholds and duration windows
  * Load balancing support via `lb_policy` directive
  * Prometheus metrics for monitoring WAF requests, detection latency, and engine health
  * Fail-open behavior when no engines are available

* **Documentation**
  * Updated README with new configuration fields and build instructions
  * Added plugin architecture documentation

* **Tests**
  * Added comprehensive test suite for engine selection and health tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->