### PR TITLE
fix(renovate): correct depName and schedule configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
   "extends": [
     "config:recommended"
   ],
-  "schedule": ["before 9am on Monday"],
+  "schedule": ["after 12am and before 1am every day"],
   "gomod": {
     "enabled": true
   },
@@ -31,7 +31,7 @@
       "description": "Update GO_VERSION in workflow files",
       "fileMatch": ["^\\.github/workflows/.+\\.yml$"],
       "matchStrings": ["GO_VERSION:\\s*\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""],
-      "depNameTemplate": "go",
+      "depNameTemplate": "golang",
       "datasourceTemplate": "golang-version",
       "versioningTemplate": "semver"
     }


### PR DESCRIPTION
修复 #27 合并时遗漏的两个配置修正：

- `depNameTemplate` 从 `go` 改为 `golang`（`golang-version` datasource 要求的正确包名）
- schedule 从每周一改为每天凌晨 0-1 点

🤖 Generated with [Claude Code](https://claude.com/claude-code)